### PR TITLE
Fix cookie setup for auth

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -42,10 +42,12 @@ export async function POST(request: NextRequest) {
 
     if (result.token) {
       console.log('🔍 LOGIN: Estableciendo cookie auth-token');
+      const isSecure = process.env.NEXTAUTH_URL?.startsWith('https');
       response.cookies.set('auth-token', result.token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: Boolean(isSecure),
         sameSite: 'lax',
+        path: '/',
         maxAge: 7 * 24 * 60 * 60 // 7 días
       });
     } else {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -10,10 +10,12 @@ export async function POST(request: NextRequest) {
     });
 
     // Eliminar cookie de autenticación
+    const isSecure = process.env.NEXTAUTH_URL?.startsWith('https');
     response.cookies.set('auth-token', '', {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: Boolean(isSecure),
       sameSite: 'lax',
+      path: '/',
       maxAge: 0 // Expira inmediatamente
     });
 

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -46,10 +46,12 @@ export async function POST(request: NextRequest) {
     });
 
     if (result.token) {
+      const isSecure = process.env.NEXTAUTH_URL?.startsWith('https');
       response.cookies.set('auth-token', result.token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: Boolean(isSecure),
         sameSite: 'lax',
+        path: '/',
         maxAge: 7 * 24 * 60 * 60 // 7 días
       });
     }


### PR DESCRIPTION
## Summary
- fix secure cookie detection and ensure root path for auth token
- apply same options to registration and logout routes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a2ed74b083259d4cba7fbfc14bf5